### PR TITLE
Add URL param and link sharing 🔗

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -237,6 +237,11 @@
       "resolved": "https://registry.npmjs.org/console-clear/-/console-clear-1.1.1.tgz",
       "integrity": "sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ=="
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
@@ -263,6 +268,11 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -543,6 +553,17 @@
       "integrity": "sha512-nxwImTPRHvUQRhop00Zxpwv5bCAqtxUcBtqGtqnQNNansL7wx1L8jzK6+Zz0elubI2wF/5XF4XitYa5XORykmg==",
       "dev": true
     },
+    "query-string": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.0.tgz",
+      "integrity": "sha512-In3o+lUxlgejoVJgwEdYtdxrmlL0cQWJXj0+kkI7RWVo7hg5AhFtybeKlC9Dpgbr8eOC4ydpEh8017WwyfzqVQ==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -737,6 +758,16 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
+    },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -237,11 +237,6 @@
       "resolved": "https://registry.npmjs.org/console-clear/-/console-clear-1.1.1.tgz",
       "integrity": "sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ=="
     },
-    "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-    },
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
@@ -268,11 +263,6 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
-    },
-    "filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -553,16 +543,10 @@
       "integrity": "sha512-nxwImTPRHvUQRhop00Zxpwv5bCAqtxUcBtqGtqnQNNansL7wx1L8jzK6+Zz0elubI2wF/5XF4XitYa5XORykmg==",
       "dev": true
     },
-    "query-string": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.0.tgz",
-      "integrity": "sha512-In3o+lUxlgejoVJgwEdYtdxrmlL0cQWJXj0+kkI7RWVo7hg5AhFtybeKlC9Dpgbr8eOC4ydpEh8017WwyfzqVQ==",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      }
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -758,16 +742,6 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
-    },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-    },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"svelte": "^3.32.1"
 	},
 	"dependencies": {
+		"query-string": "^6.14.0",
 		"sirv-cli": "^1.0.11"
 	},
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"svelte": "^3.32.1"
 	},
 	"dependencies": {
-		"query-string": "^6.14.0",
+		"querystringify": "^2.2.0",
 		"sirv-cli": "^1.0.11"
 	},
 	"scripts": {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -29,7 +29,11 @@
 			return
 		}
 		timestamp = new Date(snowflake / 4194304 + 1420070400000)
-		window.history.replaceState(null, null, qs.stringify({ s: snowflake }))
+		window.history.replaceState(
+			null,
+			null,
+			'?' + qs.stringify({ s: snowflake })
+		)
 	}
 	update()
 </script>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,5 @@
 <script>
-	import qs from 'query-string'
+	import qs from 'querystringify'
 	import { selectTextOnFocus, blurOnEscape } from './inputDirectives.js'
 	import Help from './Help.svelte'
 	import Output from './Output.svelte'

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,9 +6,6 @@
 	import Credits from './Credits.svelte'
 	import Github from './Github.svelte'
 
-	console.log(location.search)
-	console.log(qs.parse(location.search))
-
 	let snowflake = qs.parse(location.search).s || '',
 		timestamp,
 		error

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -3,6 +3,7 @@
 	import { selectTextOnFocus, blurOnEscape } from './inputDirectives.js'
 	import Help from './Help.svelte'
 	import Output from './Output.svelte'
+	import Share, { url } from './Share.svelte'
 	import Credits from './Credits.svelte'
 	import Github from './Github.svelte'
 
@@ -10,8 +11,10 @@
 		timestamp,
 		error
 
+	$: update(snowflake)
+
 	// Refresh the output
-	const update = () => {
+	function update() {
 		timestamp = null
 		error = null
 		if (!snowflake.trim()) return
@@ -32,7 +35,6 @@
 			'?' + qs.stringify({ s: snowflake })
 		)
 	}
-	update()
 </script>
 
 <main>
@@ -49,7 +51,6 @@
 		<input
 			type="text"
 			bind:value={snowflake}
-			on:input={update}
 			use:selectTextOnFocus
 			use:blurOnEscape
 			placeholder="e.g. 86913608335773696"

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,11 +1,15 @@
 <script>
+	import qs from 'query-string'
 	import { selectTextOnFocus, blurOnEscape } from './inputDirectives.js'
 	import Help from './Help.svelte'
 	import Output from './Output.svelte'
 	import Credits from './Credits.svelte'
 	import Github from './Github.svelte'
 
-	let snowflake = '',
+	console.log(location.search)
+	console.log(qs.parse(location.search))
+
+	let snowflake = qs.parse(location.search).s || '',
 		timestamp,
 		error
 
@@ -25,6 +29,7 @@
 			return
 		}
 		timestamp = new Date(snowflake / 4194304 + 1420070400000)
+		window.history.replaceState(null, null, qs.stringify({ s: snowflake }))
 	}
 	update()
 </script>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -29,11 +29,8 @@
 			return
 		}
 		timestamp = new Date(snowflake / 4194304 + 1420070400000)
-		window.history.replaceState(
-			null,
-			null,
-			'?' + qs.stringify({ s: snowflake })
-		)
+		window.history.replaceState(null, null, qs.stringify({ s: snowflake }, '?'))
+		url.set(window.location.href)
 	}
 </script>
 
@@ -59,6 +56,7 @@
 
 	{#if timestamp}
 		<Output {timestamp} />
+		<Share />
 		<Credits />
 	{/if}
 	{#if error}

--- a/src/Share.svelte
+++ b/src/Share.svelte
@@ -19,7 +19,7 @@
 	url.subscribe(() => (copyText = '📋 Copy'))
 </script>
 
-<div>
+<fieldset>
 	<input
 		type="text"
 		id="share-url"
@@ -28,21 +28,27 @@
 		use:blurOnEscape
 		bind:value={$url}
 	/><button on:click={copy}>{copyText}</button>
-</div>
+</fieldset>
 
 <style>
-	div {
-		font-size: 1.1em;
-		margin: 1em auto 0;
-		padding: 0.3em 0;
-		display: table;
-	}
 	input {
-		font-size: 0.9em;
 		width: 340px;
 	}
+
+	fieldset {
+		border: none;
+		margin: 2em auto;
+		padding: 0;
+	}
+
+	input,
 	button {
-		margin: 0 0 0 0.5em;
+		padding: 0.4em;
+		margin: 0 0.2em;
+		-moz-box-sizing: content-box;
+		-webkit-box-sizing: content-box;
+		box-sizing: content-box;
+		line-height: 1.2em;
 	}
 
 	@media (max-width: 639px) {

--- a/src/Share.svelte
+++ b/src/Share.svelte
@@ -1,0 +1,53 @@
+<script context="module">
+	import { writable } from 'svelte/store'
+	export const url = writable('')
+</script>
+
+<script>
+	import { selectTextOnFocus, blurOnEscape } from './inputDirectives.js'
+
+	let copyText
+
+	function copy() {
+		const input = document.getElementById('share-url')
+		input.select()
+		input.setSelectionRange(0, 999) // For mobile?
+		document.execCommand('copy')
+		copyText = '✔️ Copied!'
+	}
+
+	url.subscribe(() => (copyText = '📋 Copy'))
+</script>
+
+<div>
+	<input
+		type="text"
+		id="share-url"
+		readonly
+		use:selectTextOnFocus
+		use:blurOnEscape
+		bind:value={$url}
+	/><button on:click={copy}>{copyText}</button>
+</div>
+
+<style>
+	div {
+		font-size: 1.1em;
+		margin: 1em auto 0;
+		padding: 0.3em 0;
+		display: table;
+	}
+	input {
+		font-size: 0.9em;
+		width: 340px;
+	}
+	button {
+		margin: 0 0 0 0.5em;
+	}
+
+	@media (max-width: 639px) {
+		input {
+			width: 180px;
+		}
+	}
+</style>


### PR DESCRIPTION
Snow-Stamp can now be shared with snowflake IDs embedded in the URL.

Visiting a URL containing a snowflake will auto-fill the input field and show the output.

The URL automatically updates when a valid snowflake is entered.

Additionally, the URL is displayed below the output with a convenient button to copy it to the clipboard.

I'm not totally satisfied with the way the browser URL is always synced with the output (what if a user just wants to share snow-stamp without and ID?) but I'm leaving it until a better idea comes along.