### PR TITLE
Unix seconds/milliseconds switch and better checkboxes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
 				"dayjs": "^1.10.6",
 				"express": "^4.17.1",
 				"node-html-parser": "^3.3.6",
-				"querystringify": "^2.2.0"
+				"querystringify": "^2.2.0",
+				"svelte-media-query": "^1.1.1"
 			},
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "^19.0.0",
@@ -6357,6 +6358,11 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/svelte-media-query": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/svelte-media-query/-/svelte-media-query-1.1.1.tgz",
+			"integrity": "sha512-4UP9DaC4CNvHB7rzJiTyt2U+BMYbJslo/ZzRzzFB0IvNZIWqroPBdfAl+bcsh4j0jZI+XZSEMGrJdhv5n9Ib0g=="
+		},
 		"node_modules/symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -11514,6 +11520,11 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.38.3.tgz",
 			"integrity": "sha512-N7bBZJH0iF24wsalFZF+fVYMUOigaAUQMIcEKHO3jstK/iL8VmP9xE+P0/a76+FkNcWt+TDv2Gx1taUoUscrvw==",
 			"dev": true
+		},
+		"svelte-media-query": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/svelte-media-query/-/svelte-media-query-1.1.1.tgz",
+			"integrity": "sha512-4UP9DaC4CNvHB7rzJiTyt2U+BMYbJslo/ZzRzzFB0IvNZIWqroPBdfAl+bcsh4j0jZI+XZSEMGrJdhv5n9Ib0g=="
 		},
 		"symbol-tree": {
 			"version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"dayjs": "^1.10.6",
 		"express": "^4.17.1",
 		"node-html-parser": "^3.3.6",
-		"querystringify": "^2.2.0"
+		"querystringify": "^2.2.0",
+		"svelte-media-query": "^1.1.1"
 	},
 	"scripts": {
 		"build": "rollup -c",

--- a/src/Checkbox.svelte
+++ b/src/Checkbox.svelte
@@ -1,0 +1,87 @@
+<script>
+	export let checked = false
+	export let text
+</script>
+
+<label class="check">
+	{text}
+	<input type="checkbox" bind:checked />
+	<span class="checkmark" />
+</label>
+
+<style>
+	/* https://www.w3schools.com/howto/howto_css_custom_checkbox.asp */
+	/* Customize the label (the container) */
+	.check {
+		display: block;
+		position: relative;
+		padding-left: 35px;
+		margin-bottom: 12px;
+		cursor: pointer;
+		font-size: 18px;
+		-webkit-user-select: none;
+		-moz-user-select: none;
+		-ms-user-select: none;
+		user-select: none;
+	}
+
+	/* Hide the browser's default checkbox */
+	.check input {
+		position: absolute;
+		opacity: 0;
+		cursor: pointer;
+		height: 0;
+		width: 0;
+	}
+
+	/* Create a custom checkbox */
+	.checkmark {
+		position: absolute;
+		top: 0;
+		left: 0;
+		height: 25px;
+		width: 25px;
+		background-color: #ddd;
+	}
+
+	/* On mouse-over, add a grey background color */
+	.check:hover input ~ .checkmark {
+		background-color: #ccc;
+	}
+
+	/* When the checkbox is checked, add a blue background */
+	.check input:checked ~ .checkmark {
+		background-color: #008dad;
+	}
+
+	/* Create the checkmark/indicator (hidden when not checked) */
+	.checkmark:after {
+		content: '';
+		position: absolute;
+		display: none;
+	}
+
+	/* Show the checkmark when checked */
+	.check input:checked ~ .checkmark:after {
+		display: block;
+	}
+
+	/* Style the checkmark/indicator */
+	.check .checkmark:after {
+		left: 9px;
+		top: 5px;
+		width: 5px;
+		height: 10px;
+		border: solid white;
+		border-width: 0 3px 3px 0;
+		-webkit-transform: rotate(45deg);
+		-ms-transform: rotate(45deg);
+		transform: rotate(45deg);
+	}
+
+	@media (max-width: 749px) {
+		.check {
+			font-size: 16px;
+		}
+	}
+</style>

--- a/src/Output.svelte
+++ b/src/Output.svelte
@@ -1,5 +1,20 @@
 <script>
+	import MediaQuery from 'svelte-media-query'
 	import { formatLocale, getTimeZoneName, getUNIX, getISO } from './format'
+	import Switch from './Switch.svelte'
+	import { getLocalStorageBoolean } from './util'
+
+	let showUnixMilliseconds = getLocalStorageBoolean(
+		'showUnixMilliseconds',
+		false
+	)
+	let unixUnits
+	$: unixUnits = showUnixMilliseconds ? 'milliseconds' : 'seconds'
+
+	$: (() => {
+		localStorage.setItem('showUnixMilliseconds', showUnixMilliseconds)
+	})(showUnixMilliseconds)
+
 	export let timestamp
 </script>
 
@@ -11,8 +26,18 @@
 	<p><time datetime={getISO(timestamp)}>{formatLocale(timestamp)}</time></p>
 	<hr />
 	<!-- Unix timestamp -->
-	<p class="label">UNIX</p>
-	<p><samp>{getUNIX(timestamp)}</samp></p>
+	<div style="display: flex">
+		<div style="flex: 1 0">
+			<p class="label">UNIX {unixUnits}</p>
+			<p><samp>{getUNIX(timestamp, showUnixMilliseconds)}</samp></p>
+		</div>
+		<div>
+			<p class="label" style="margin-bottom: 9px;">Units</p>
+			<MediaQuery query="(max-width: 749px)" let:matches>
+				<Switch bind:checked={showUnixMilliseconds} small={matches} />
+			</MediaQuery>
+		</div>
+	</div>
 	<hr />
 	<!-- ISO 8601 -->
 	<p class="label">ISO 8601</p>

--- a/src/Output.svelte
+++ b/src/Output.svelte
@@ -32,8 +32,8 @@
 			<p><samp>{getUNIX(timestamp, showUnixMilliseconds)}</samp></p>
 		</div>
 		<div>
-			<p class="label" style="margin-bottom: 9px;">Units</p>
 			<MediaQuery query="(max-width: 749px)" let:matches>
+				<p class="label" style="margin-bottom: {matches ? 5 : 9}px;">Units</p>
 				<Switch bind:checked={showUnixMilliseconds} small={matches} />
 			</MediaQuery>
 		</div>

--- a/src/Share.svelte
+++ b/src/Share.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { selectTextOnFocus, blurOnEscape } from './util.js'
+	import Checkbox from './Checkbox.svelte'
 
 	export let url
 	export let shareStamp
@@ -20,17 +21,15 @@
 </script>
 
 <fieldset>
-	{#if dynamicMode}
-		<label>
-			<input type="checkbox" bind:checked={shareStamp} />
-			<span>Show timestamp when sharing</span>
-			<span>(e.g. Discord embeds)</span>
-		</label>
-	{/if}
-	<label>
-		<input type="checkbox" bind:checked={shortenSnowflake} />
-		Shorten snowflake in URL
-	</label>
+	<div class="options">
+		{#if dynamicMode}
+			<Checkbox
+				text="Show timestamp on Discord/Twitter"
+				bind:checked={shareStamp}
+			/>
+		{/if}
+		<Checkbox text="Shorten snowflake in URL" bind:checked={shortenSnowflake} />
+	</div>
 	<input
 		type="text"
 		id="share-url"
@@ -42,22 +41,19 @@
 </fieldset>
 
 <style>
-	label {
-		margin-bottom: 0.3em;
-	}
-
 	#share-url {
 		width: 380px;
 	}
 
-	input[type='checkbox'] {
-		margin-right: 0.3em;
-	}
-
 	fieldset {
 		border: none;
-		margin: 2em auto;
+		margin: 1.8em auto 2em;
 		padding: 0;
+	}
+
+	.options {
+		text-align: left;
+		margin-left: 160px;
 	}
 
 	input[type='text'],
@@ -70,11 +66,10 @@
 		line-height: 1.2em;
 	}
 
-	span {
-		display: inline-block;
-	}
-
 	@media (max-width: 749px) {
+		.options {
+			margin-left: 32px;
+		}
 		#share-url {
 			width: 190px;
 		}

--- a/src/Switch.svelte
+++ b/src/Switch.svelte
@@ -1,0 +1,93 @@
+<!-- Based on https://svelte.dev/repl/35d77f2ab11e4197a19ffd8e7c4ac74e?version=3.9.1 -->
+<script>
+	export let checked = false
+	export let enabledColor = '#aaa'
+	export let bgColor = '#999'
+	export let small = false
+</script>
+
+<label
+	class="switch{small ? ' small' : ''}"
+	style="--enabled-color:{enabledColor};--bg-color:{bgColor}"
+>
+	<input type="checkbox" bind:checked />
+	<span class="slider" />
+</label>
+
+<style>
+	.switch {
+		position: relative;
+		display: inline-block;
+		width: 60px;
+		height: 34px;
+	}
+
+	.switch.small {
+		width: 48px;
+		height: 26px;
+	}
+
+	.switch input {
+		opacity: 0;
+		width: 0;
+		height: 0;
+	}
+
+	.slider {
+		position: absolute;
+		cursor: pointer;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		/*noinspection CssUnresolvedCustomProperty*/
+		background-color: var(--bg-color);
+		-webkit-transition: 0.2s;
+		transition: 0.2s;
+		border-radius: 34px;
+	}
+
+	.small .slider {
+		border-radius: 26px;
+	}
+
+	.slider:before {
+		position: absolute;
+		content: '';
+		height: 26px;
+		width: 26px;
+		left: 4px;
+		bottom: 4px;
+		background-color: white;
+		-webkit-transition: 0.2s;
+		transition: 0.2s;
+		border-radius: 50%;
+	}
+
+	.small .slider:before {
+		height: 20px;
+		width: 20px;
+		left: 3px;
+		bottom: 3px;
+	}
+
+	input:checked + .slider {
+		background-color: var(--enabled-color);
+	}
+
+	input:checked + .slider {
+		box-shadow: 0 0 1px var(--enabled-color);
+	}
+
+	input:checked + .slider:before {
+		-webkit-transform: translateX(26px);
+		-ms-transform: translateX(26px);
+		transform: translateX(26px);
+	}
+
+	.small input:checked + .slider:before {
+		-webkit-transform: translateX(22px);
+		-ms-transform: translateX(22px);
+		transform: translateX(22px);
+	}
+</style>

--- a/src/format.js
+++ b/src/format.js
@@ -2,8 +2,10 @@ export function formatLocale(date) {
 	return date.toLocaleString()
 }
 
-export function getUNIX(date) {
-	return (date.getTime() / 1000) | 0
+export function getUNIX(date, useMS) {
+	let unix = date.getTime()
+	if (!useMS) unix = (unix / 1000) | 0
+	return unix
 }
 
 export function getISO(date) {


### PR DESCRIPTION
This PR adds a toggle switch to the UNIX output to change between seconds and milliseconds. Since Javascript uses milliseconds, it seems appropriate to at least offer the option. This setting is saved in local storage.

![unit-toggle-1](https://user-images.githubusercontent.com/1789096/125149355-a0dfb180-e106-11eb-8a44-5f00ac216b34.gif)

I also replaced the ugly/tiny default checkboxes with better ones.

![image](https://user-images.githubusercontent.com/1789096/125149361-a937ec80-e106-11eb-8529-27ed2a7ad548.png)
