### PR TITLE
refactor: Use BigInt for snowflake conversion

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -1,6 +1,6 @@
 // Converts a snowflake ID string into a JS Date object using the provided epoch (in ms), or Discord's epoch if not provided
 export function convertSnowflakeToDate(snowflake, epoch = DISCORD_EPOCH) {
-	return new Date(snowflake / 4194304 + epoch)
+	return new Date(Number(BigInt(snowflake) >> 22n) + epoch)
 }
 
 export const DISCORD_EPOCH = 1420070400000

--- a/src/format.js
+++ b/src/format.js
@@ -4,7 +4,7 @@ export function formatLocale(date) {
 
 export function getUNIX(date, useMS) {
 	let unix = date.getTime()
-	if (!useMS) unix = (unix / 1000) | 0
+	if (!useMS) unix = Number((BigInt(unix) / 1000n) | 0n)
 	return unix
 }
 


### PR DESCRIPTION
Using BigInt for snowflake conversions removes issues with integer overflow. For current IDs, this is not an issue. However, as the IDs grow, this could cause inaccurate conversions.

I also used BigInt for converting the timestamp from MS into seconds to fix overflowing for IDs created after 2038-01-19T03:14:08.000Z (when epoch overflows 32 bits).

[BigInt Browser compatibility](https://caniuse.com/?search=bigint)

Note that some of the tests in `embed.test.js` are failing. However, this occurred even with the original code, so it is out of scope for this pull request.