### PR TITLE
:recycle: Move Declaration before it use, isNaN -> Number.isNaN and w…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "snow-stamp",
 			"version": "0.2.0",
 			"dependencies": {
 				"dayjs": "^1.10.7",

--- a/src/convert.js
+++ b/src/convert.js
@@ -1,3 +1,5 @@
+export const DISCORD_EPOCH = 1420070400000
+
 // Converts a snowflake ID string into a JS Date object using the provided epoch (in ms), or Discord's epoch if not provided
 export function convertSnowflakeToDate(snowflake, epoch = DISCORD_EPOCH) {
 	// Convert snowflake to BigInt to extract timestamp bits
@@ -6,19 +8,27 @@ export function convertSnowflakeToDate(snowflake, epoch = DISCORD_EPOCH) {
 	return new Date(Number(milliseconds) + epoch)
 }
 
-export const DISCORD_EPOCH = 1420070400000
-
 // Validates a snowflake ID string and returns a JS Date object if valid
 export function validateSnowflake(snowflake, epoch) {
 	if (!Number.isInteger(+snowflake)) {
-		throw "That doesn't look like a snowflake. Snowflakes contain only numbers."
+		throw new Error(
+			"That doesn't look like a snowflake. Snowflakes contain only numbers."
+		)
 	}
+
 	if (snowflake < 4194304) {
-		throw "That doesn't look like a snowflake. Snowflakes are much larger numbers."
+		throw new Error(
+			"That doesn't look like a snowflake. Snowflakes are much larger numbers."
+		)
 	}
+
 	const timestamp = convertSnowflakeToDate(snowflake, epoch)
-	if (isNaN(timestamp.getTime())) {
-		throw "That doesn't look like a snowflake. Snowflakes have fewer digits."
+
+	if (Number.isNaN(timestamp.getTime())) {
+		throw new Error(
+			"That doesn't look like a snowflake. Snowflakes have fewer digits."
+		)
 	}
+
 	return timestamp
 }


### PR DESCRIPTION
`Number.isNaN`

From Mozilla: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN

> The Number.isNaN() method determines whether the passed value is NaN and its type is Number. It is a more robust version of the original, global isNaN().

About wrapping the error in the `Error` class check:

https://stackoverflow.com/questions/9156176